### PR TITLE
Delay statistics gathering to catch actual usage

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -6,48 +6,13 @@
 
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-element-mixin.html">
   <link rel="import" href="../../polymer/polymer-element.html">
 </head>
 
 <body>
-  <div id="dom-modules">
-    <dom-module id="test-foo">
-      <template>
-        <style>
-          :host {
-            display: block;
-          }
-        </style>
-        <div part="text" id="text">text</div>
-      </template>
-    </dom-module>
-  </div>
-
-  <script>
-  document.addEventListener('WebComponentsReady', function() {
-    class TestFoo extends Vaadin.ElementMixin(Polymer.Element) {
-      static get is() {
-        return 'test-foo';
-      }
-    }
-    customElements.define(TestFoo.is, TestFoo);
-  });
-  </script>
-
-  <test-fixture id="default">
-    <template>
-      <test-foo></test-foo>
-    </template>
-  </test-fixture>
-
   <script>
     describe('basic functionality', function() {
-
-      beforeEach(() => {
-        fixture('default');
-      });
 
       it('should define window.Vaadin', function() {
         expect(window.Vaadin).to.exist;
@@ -57,12 +22,20 @@
         expect(window.Vaadin.developmentMode).to.exist;
       });
 
-      it('should store the class entry in registrations', function() {
+      it('should store the class entry in registrations once instance created', function() {
+        class TestFoo extends Vaadin.ElementMixin(Polymer.Element) {
+          static get is() {
+            return 'test-foo';
+          }
+        }
+        customElements.define(TestFoo.is, TestFoo);
+        document.createElement('test-foo');
+        Polymer.flush();
         expect(window.Vaadin.registrations).to.be.array;
         expect(window.Vaadin.registrations[0].is).to.equal('test-foo');
       });
 
-      it('should load usage statistics only on localhost', function() {
+      it('should collect usage statistics only on localhost', function() {
         expect(window.Vaadin.developmentModeCallback).to.exist;
         expect(window.Vaadin.developmentModeCallback['vaadin-usage-statistics']).to.exist;
       });
@@ -81,30 +54,38 @@
         window.Vaadin.developmentModeCallback = ref;
       });
 
-      it('should load usage statistics once per class', function() {
+      it('should collect usage statistics once per class', () => {
         const spy = sinon.spy(window.Vaadin.developmentModeCallback, 'vaadin-usage-statistics');
 
-        class TestBar extends Vaadin.ElementMixin(Polymer.Element) {
+        class TestBaz extends Vaadin.ElementMixin(Polymer.Element) {
           static get is() {
-            return 'test-bar';
+            return 'test-baz';
           }
         }
+        customElements.define(TestBaz.is, TestBaz);
+
+        const elem1 = document.createElement('test-baz');
+        document.body.appendChild(elem1);
+        Polymer.flush();
         expect(spy).to.be.calledOnce;
-        customElements.define(TestBar.is, TestBar);
+
+        const elem2 = document.createElement('test-baz');
+        document.body.appendChild(elem2);
+        Polymer.flush();
         expect(spy).to.be.calledOnce;
-        const elem = document.createElement('test-bar');
-        document.body.appendChild(elem);
-        expect(spy).to.be.calledOnce;
-        class TestBar2 extends Vaadin.ElementMixin(Polymer.Element) {
+
+        class TestBaz2 extends Vaadin.ElementMixin(Polymer.Element) {
           static get is() {
-            return 'test-bar2';
+            return 'test-baz2';
           }
         }
-        customElements.define(TestBar2.is, TestBar2);
+        customElements.define(TestBaz2.is, TestBaz2);
+
+        const elem3 = document.createElement('test-baz2');
+        document.body.appendChild(elem3);
+        Polymer.flush();
         expect(spy).to.be.calledTwice;
       });
-
-
     });
   </script>
 </body>

--- a/test/doctype.html
+++ b/test/doctype.html
@@ -5,21 +5,14 @@
   <title>doctype test</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../../polymer/polymer-element.html">
   <link rel="import" href="../vaadin-element-mixin.html">
 </head>
 
 <body>
-
-  <test-fixture id="default">
-    <template>
-      <x-element></x-element>
-    </template>
-  </test-fixture>
 
   <script>
     window.addEventListener('WebComponentsReady', () => {
@@ -38,7 +31,8 @@
       it('should warn about doctype', () => {
         const _warn = console.warn;
         const spy = console.warn = sinon.spy();
-        fixture('default');
+        const elem = document.createElement('x-element');
+        document.body.appendChild(elem);
         console.warn = _warn;
         expect(spy.called).to.be.true;
       });

--- a/vaadin-element-mixin.html
+++ b/vaadin-element-mixin.html
@@ -1,3 +1,6 @@
+<link rel="import" href="../polymer/lib/utils/async.html">
+<link rel="import" href="../polymer/lib/utils/debounce.html">
+<link rel="import" href="../polymer/lib/utils/flush.html">
 <link rel="import" href="../vaadin-usage-statistics/vaadin-usage-statistics.html">
 
 <script>
@@ -18,37 +21,38 @@ window['Vaadin'].developmentModeCallback['vaadin-usage-statistics'] = function()
   }
 };
 
+let statsJob;
+
 /**
  * @polymerMixin
  * @memberof Vaadin
  */
-Vaadin.ElementMixin = superClass => {
-  try {
-    return class VaadinElementMixin extends superClass {
-      /** @protected */
-      static _finalizeClass() {
-        super._finalizeClass();
+Vaadin.ElementMixin = superClass => class VaadinElementMixin extends superClass {
+  /** @protected */
+  static _finalizeClass() {
+    super._finalizeClass();
 
-        // Registers a class prototype for telemetry purposes.
-        if (this.is) {
-          window.Vaadin.registrations.push(this);
-        }
+    // Registers a class prototype for telemetry purposes.
+    if (this.is) {
+      window.Vaadin.registrations.push(this);
+
+      if (window.Vaadin.developmentModeCallback) {
+        statsJob = Polymer.Debouncer.debounce(statsJob,
+          Polymer.Async.idlePeriod, () => {
+            window.Vaadin.developmentModeCallback['vaadin-usage-statistics']();
+          }
+        );
+        Polymer.enqueueDebouncer(statsJob);
       }
-      ready() {
-        super.ready();
-        if (document.doctype === null) {
-          console.warn(
-            'Vaadin components require the "standards mode" declaration. Please add <!DOCTYPE html> to the HTML document.'
-          );
-        }
-      }
-    };
-  } finally {
-    // This is run every time a new class is declared, not every time an instance is created
-    if (window.Vaadin.developmentModeCallback) {
-      window.Vaadin.developmentModeCallback['vaadin-usage-statistics']();
+    }
+  }
+  ready() {
+    super.ready();
+    if (document.doctype === null) {
+      console.warn(
+        'Vaadin components require the "standards mode" declaration. Please add <!DOCTYPE html> to the HTML document.'
+      );
     }
   }
 };
-
 </script>


### PR DESCRIPTION
Fixes #17

I removed the `try.. finally` trick as by that time we do not yet know the element name to be defined.

From now on, we only send statistics if there is at least one instance created: generally, Polymer delays most of registrations work until instantiating, this has been since Polymer 1.4 with `lazyRegister`.

Also, presence of the class without instances can mean "someone removed the component but forgot to remove the import" which sometimes happens in the real apps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-mixin/18)
<!-- Reviewable:end -->
